### PR TITLE
feat: add coverage xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,38 @@ jobs:
 
       - name: Test
         run: cargo nextest run --all --all-targets --all-features
+
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install Rust stable toolchain (with coverage instrumentation)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          components: llvm-tools-preview
+
+      - name: Restore cached toolchain
+        id: rust-cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install grcov
+        if: steps.rust-cache.output.cache-hit != 'true'
+        run: |
+          cargo install grcov
+
+      - name: Generate coverage
+        run: cargo xtask
+
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/cov.lcov
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target/
 **/dist/
 **/Cargo.lock
+**/coverage/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "yew-and-bulma",
   "yew-and-bulma-macros",
+  "xtask",
   "examples/*",
 ]
 default-members = [

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build status](https://img.shields.io/github/actions/workflow/status/filipdutescu/yew-and-bulma/ci.yml?branch=main&style=flat-square)](https://github.com/filipdutescu/yew-and-bulma/actions)
 [![Docs](https://img.shields.io/docsrs/yew-and-bulma/latest?style=flat-square)](https://docs.rs/yew-and-bulma/)
 ![Licenses](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue?style=flat-square)
+[![codecov](https://codecov.io/gh/filipdutescu/yew-and-bulma/branch/main/graph/badge.svg?token=3BGBGWI5V0)](https://codecov.io/gh/filipdutescu/yew-and-bulma)
 
   <h3>Bulma CSS components for Yew</h3>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 20%
+
+ignore:
+  - examples/
+  - xtask/

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+authors = ["Filip Dutescu <filip@hucksy.dev>"]
+repository = "https://github.com/filipdutescu/yew-and-bulma"
+homepage = "https://github.com/filipdutescu/yew-and-bulma"
+license = "MIT OR Apache-2.0"
+keywords = ["code", "coverage", "xtask"]
+categories = ["Command line utilities", "Development tools"]
+description = "Generate code coverage reports"
+rust-version = "1.60"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+open = "3.2.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,135 @@
+use std::{
+    fs::{create_dir_all, read_dir, remove_dir_all, remove_file},
+    io,
+    path::Path,
+    process::{exit, Command, Stdio},
+};
+
+fn main() -> io::Result<()> {
+    let mut show_cov = false;
+    let mut verbose = false;
+    for flag in std::env::args() {
+        if flag == "--show" {
+            show_cov = true;
+        }
+        if flag == "--verbose" || flag == "-v" {
+            verbose = true;
+        }
+    }
+
+    let coverage_dir_path = std::path::Path::new("coverage");
+    if coverage_dir_path.is_dir() {
+        remove_dir_all(coverage_dir_path)?;
+    }
+    create_dir_all(coverage_dir_path)?;
+
+    println!("Gathering coverage from tests...");
+    let mut report_cmd = Command::new("cargo");
+    if verbose {
+        report_cmd.stdout(Stdio::null());
+    }
+    report_cmd.env("CARGO_INCREMENTAL", "0");
+    report_cmd.env("RUSTFLAGS", "-C instrument-coverage");
+    report_cmd.env("LLVM_PROFILE_FILE", "coverage/test-%p-%m.profraw");
+    report_cmd.arg("nextest");
+    report_cmd.arg("run");
+    report_cmd.arg("--all");
+    report_cmd.arg("--all-targets");
+    report_cmd.arg("--all-features");
+
+    let exit_code = run_cmd!(report_cmd);
+    if !exit_code.success() {
+        println!("Error during coverage gathering: {exit_code}");
+        exit(3)
+    }
+
+    let format = if show_cov { "html" } else { "lcov" };
+    let output_file = format!("coverage/cov.{format}");
+    println!("Generating coverage report at `{output_file}`...");
+
+    let mut merge_reports_cmd = Command::new("grcov");
+    if verbose {
+        merge_reports_cmd.stdout(Stdio::null());
+    }
+    merge_reports_cmd.args([
+        ".",
+        "-s",
+        ".",
+        "--binary-path",
+        "./target/debug/",
+        "-t",
+        format,
+        "--branch",
+        "--ignore-not-existing",
+        "-o",
+        &output_file,
+    ]);
+
+    let exit_code = run_cmd!(merge_reports_cmd);
+    if !exit_code.success() {
+        println!("Error during coverage report generation: {exit_code}");
+        exit(4)
+    }
+
+    cleanup_raw_data(coverage_dir_path)?;
+    if show_cov {
+        let output_file = format!("{output_file}/index.html");
+        if let Err(err) = open::that(output_file) {
+            println!("Error while trying to show report: {err:?}");
+            exit(5)
+        }
+    } else {
+        println!("Coverage file found at {output_file}.");
+    }
+
+    Ok(())
+}
+
+fn cleanup_raw_data(coverage_dir_path: &Path) -> io::Result<()> {
+    for f in read_dir(coverage_dir_path)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file())
+    {
+        if let Some(ext) = f.extension() {
+            if ext == "profraw" {
+                if let Err(err) = remove_file(&f) {
+                    let file_path = f.display();
+                    println!("WARN: Failed to remove raw coverage file {file_path}: {err}");
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[macro_export]
+macro_rules! run_cmd {
+    ($cmd:ident) => {{
+        let mut process = match $cmd.spawn() {
+            Ok(process) => process,
+            Err(err) => {
+                println!(
+                    "Failed to spawn process `{}`: {:?}",
+                    $cmd.get_program()
+                        .to_os_string()
+                        .into_string()
+                        .ok()
+                        .unwrap_or("invalid characters in program name".to_owned()),
+                    err
+                );
+                exit(1)
+            }
+        };
+        let output = match process.wait() {
+            Ok(output) => output,
+            Err(err) => {
+                println!("Failed to wait for output: {err:?}");
+                exit(2)
+            }
+        };
+
+        output
+    }};
+}


### PR DESCRIPTION
Add source code coverage using Rust's [instrument coverage features][llvm]. Create an [xtask crate][xtask] to automate the report generation steps. This should hopefully lead to an increase in stability and reliability, by stimulating an increase in tests.

Add a cargo alias for `xtask`, to simplify calling.

Update the CI to upload coverage reports to [CodeCov][codecov] for reporting.

[llvm]: https://doc.rust-lang.org/rustc/instrument-coverage.html
[xtask]: https://github.com/matklad/cargo-xtask
[codecov]: https://about.codecov.io/

Fixes: #13